### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.md linguist-detectable=true
+*.md linguist-documentation=false
+*.xml linguist-detectable=true


### PR DESCRIPTION
This file enables this repo's laguage statistics to let it count Markdown.