### PR TITLE
Update ConsoleREPL.cs

### DIFF
--- a/Samples/ConsoleREPL/ConsoleREPL.cs
+++ b/Samples/ConsoleREPL/ConsoleREPL.cs
@@ -141,7 +141,7 @@ namespace PowerFxHostSamples
                     separator = "";
                     foreach (var row in table.Rows)
                     {
-                        resultString += separator + PrintResult(row.Value);
+                        resultString += separator + PrintResult(row.IsValue ? row.Value : row.Blank);
                         separator = ", ";
                     }
                     resultString += ")";


### PR DESCRIPTION
Code throwing "unexpected type in PrintResult" if Table contains blank row.
For instance: Table({a:1},{a:2},If(1<0,{a:3}),{a:4},{a:5})