### PR TITLE
NullRef when Context is invalid.

### DIFF
--- a/Samples/WebDemo/Controllers/EvaluationController.cs
+++ b/Samples/WebDemo/Controllers/EvaluationController.cs
@@ -94,7 +94,7 @@ namespace PowerFxService.Controllers
                 {
                     error = ex.Message,
                     tokens = tokens,
-                    parse = JsonSerializer.Serialize(check.Parse.Root, _jsonSerializerOptions)
+                    parse = check != null ? JsonSerializer.Serialize(check.Parse.Root, _jsonSerializerOptions) : null
                 });
             }
             finally


### PR DESCRIPTION
If Context is invalid, result of check would be null, hence adding the condition.
